### PR TITLE
fix: recursively look for TS sources

### DIFF
--- a/packages/base/util/hasTSSourcesSync.cjs
+++ b/packages/base/util/hasTSSourcesSync.cjs
@@ -1,7 +1,24 @@
+const path = require('path')
 const fs = require('./projectFs.cjs')
 const once = require('./once.cjs')
 
-module.exports = once(function hasTSSourcesSync() {
-  const files = fs.readdirSync('src')
-  return files.some((f) => /\.[cm]?tsx?$/.test(f) && !/\.d\.[cm]?tsx?$/.test(f))
-})
+function hasTSSources(path, depth) {
+  if (depth > 10) return false
+  const files = fs.readdirSync(path, { withFileTypes: true })
+  // first check files in this directory
+  if (
+    files.some(
+      (f) =>
+        f.isFile() &&
+        /\.[cm]?tsx?$/.test(f.name) &&
+        !/\.d\.[cm]?tsx?$/.test(f.name)
+    )
+  )
+    return true
+  // if there were no TS files in this directory, recursively check subdirectories
+  return files.some(
+    (f) => f.isDirectory() && hasTSSources(path.join(path, f.name), depth + 1)
+  )
+}
+
+module.exports = once(() => hasTSSources('src', 0))

--- a/packages/base/util/hasTSSourcesSync.cjs
+++ b/packages/base/util/hasTSSourcesSync.cjs
@@ -17,7 +17,8 @@ function hasTSSources(haystack, depth) {
     return true
   // if there were no TS files in this directory, recursively check subdirectories
   return files.some(
-    (f) => f.isDirectory() && hasTSSources(path.join(haystack, f.name), depth + 1)
+    (f) =>
+      f.isDirectory() && hasTSSources(path.join(haystack, f.name), depth + 1)
   )
 }
 

--- a/packages/base/util/hasTSSourcesSync.cjs
+++ b/packages/base/util/hasTSSourcesSync.cjs
@@ -2,9 +2,9 @@ const path = require('path')
 const fs = require('./projectFs.cjs')
 const once = require('./once.cjs')
 
-function hasTSSources(path, depth) {
+function hasTSSources(haystack, depth) {
   if (depth > 10) return false
-  const files = fs.readdirSync(path, { withFileTypes: true })
+  const files = fs.readdirSync(haystack, { withFileTypes: true })
   // first check files in this directory
   if (
     files.some(
@@ -17,7 +17,7 @@ function hasTSSources(path, depth) {
     return true
   // if there were no TS files in this directory, recursively check subdirectories
   return files.some(
-    (f) => f.isDirectory() && hasTSSources(path.join(path, f.name), depth + 1)
+    (f) => f.isDirectory() && hasTSSources(path.join(haystack, f.name), depth + 1)
   )
 }
 


### PR DESCRIPTION
If there are no TS files in `src`, but directories under `src` have TS files, the current logic fails to detect that the project has TS files.